### PR TITLE
RDKB_55149: [HUB6-64B] Fix RdkXdslManager crash

### DIFF
--- a/source/TR-181/integration_src.shared/xdsl_apis.c
+++ b/source/TR-181/integration_src.shared/xdsl_apis.c
@@ -545,7 +545,7 @@ static ANSC_STATUS DmlXdslSetParamValues( char *pComponent, char *pBus, char *pP
 }
 
 /* * DmlXdslGetLowerLayersInstanceInOtherAgent() */
-static ANSC_STATUS DmlXdslGetLowerLayersInstanceInOtherAgent( XDSL_NOTIFY_ENUM enNotifyAgent, char *pLowerLayers, INT *piInstanceNumber )
+static ANSC_STATUS DmlXdslGetLowerLayersInstanceInOtherAgent( XDSL_NOTIFY_ENUM enNotifyAgent, char *pLowerLayers, ULONG *piInstanceNumber )
 {
     //Validate buffer
     if( ( NULL == pLowerLayers ) || ( NULL == piInstanceNumber ) )
@@ -984,6 +984,7 @@ ANSC_STATUS DmlXdslSetLinkStatusForWanManager( char *BaseInterface, char *LinkSt
     char                       acSetParamName[256] = {'\0'};
     char                       acSetParamValue[256] = {'\0'};
     INT                        iWANInstance   = -1;
+    ULONG                      instanceId     = -1;
 
     //Validate buffer
     if( ( NULL == BaseInterface ) || ( NULL == LinkStatus ) )
@@ -993,7 +994,8 @@ ANSC_STATUS DmlXdslSetLinkStatusForWanManager( char *BaseInterface, char *LinkSt
     }
 
     //Get Instance for corresponding name
-    DmlXdslGetLowerLayersInstanceInOtherAgent( NOTIFY_TO_WAN_AGENT, BaseInterface, &iWANInstance );
+    DmlXdslGetLowerLayersInstanceInOtherAgent( NOTIFY_TO_WAN_AGENT, BaseInterface, &instanceId );
+    iWANInstance = (INT)instanceId;
 
     CcspTraceInfo(("%s %d BaseInterface=[%s] iWANInstance=[%d]\n", __FUNCTION__, __LINE__, BaseInterface, iWANInstance));
     //Index is not present. so no need to do anything any WAN instance


### PR DESCRIPTION
Reason for change: Fix the rdk xdsl manager crash when running as 64bit arch.

Test Procedure: Make sure xdslmanager is running and WAN connection established.

Priority:P1

Change-Id: I7815dbdb7c26887cb5667b9a4e038bdaf65e43d6 Risks:Low
Signed-off-by: Vysakh A V <vysakh.venugopal@sky.uk>
(cherry picked from commit 3bb8988bf95d4446a0ff16e995c9977960fe5cbf) (cherry picked from commit 239d8821d9417d0079313ff42b0ab9ac8d5653c6)