### PR TITLE
RDKCOM-5005 RDKBDEV-2852 : Fix for unable to set Device.DSL.Line.1.Enable to false.

### DIFF
--- a/source/TR-181/integration_src.shared/xdsl_apis.c
+++ b/source/TR-181/integration_src.shared/xdsl_apis.c
@@ -351,7 +351,10 @@ ANSC_STATUS DmlXdslLineSetEnable( INT LineIndex, BOOL Enable )
 
     memset(&req_param, 0, sizeof(req_param));
     snprintf(req_param.name, sizeof(req_param), XDSL_LINE_ENABLE, LineIndex);
-    snprintf(req_param.value, sizeof(req_param.value), "%d", Enable);
+    if ( Enable )
+        snprintf(req_param.value, sizeof(req_param.value), "%s", "TRUE");
+    else
+        snprintf(req_param.value, sizeof(req_param.value), "%s", "FALSE");
     req_param.type = PARAM_BOOLEAN;
 
     //Set enable/disable

--- a/source/TR-181/integration_src.shared/xdsl_apis.c
+++ b/source/TR-181/integration_src.shared/xdsl_apis.c
@@ -352,11 +352,10 @@ ANSC_STATUS DmlXdslLineSetEnable( INT LineIndex, BOOL Enable )
     memset(&req_param, 0, sizeof(req_param));
     snprintf(req_param.name, sizeof(req_param), XDSL_LINE_ENABLE, LineIndex);
     if ( Enable )
-        snprintf(req_param.value, sizeof(req_param.value), "%s", "1");
+        snprintf(req_param.value, sizeof(req_param.value), "%s", "TRUE");
     else
-        snprintf(req_param.value, sizeof(req_param.value), "%s", "0");
-    //req_param.type = PARAM_BOOLEAN;
-    req_param.type = PARAM_STRING;
+        snprintf(req_param.value, sizeof(req_param.value), "%s", "FALSE");
+    req_param.type = PARAM_BOOLEAN;
 
     //Set enable/disable
     if ( RETURN_OK != xdsl_hal_dslSetLineEnable( &req_param ) )

--- a/source/TR-181/integration_src.shared/xdsl_apis.c
+++ b/source/TR-181/integration_src.shared/xdsl_apis.c
@@ -352,10 +352,11 @@ ANSC_STATUS DmlXdslLineSetEnable( INT LineIndex, BOOL Enable )
     memset(&req_param, 0, sizeof(req_param));
     snprintf(req_param.name, sizeof(req_param), XDSL_LINE_ENABLE, LineIndex);
     if ( Enable )
-        snprintf(req_param.value, sizeof(req_param.value), "%s", "TRUE");
+        snprintf(req_param.value, sizeof(req_param.value), "%s", "1");
     else
-        snprintf(req_param.value, sizeof(req_param.value), "%s", "FALSE");
-    req_param.type = PARAM_BOOLEAN;
+        snprintf(req_param.value, sizeof(req_param.value), "%s", "0");
+    //req_param.type = PARAM_BOOLEAN;
+    req_param.type = PARAM_STRING;
 
     //Set enable/disable
     if ( RETURN_OK != xdsl_hal_dslSetLineEnable( &req_param ) )

--- a/source/TR-181/middle_layer_src/xdsl_dml.c
+++ b/source/TR-181/middle_layer_src/xdsl_dml.c
@@ -742,7 +742,7 @@ Line_SetParamBoolValue
 	{
 	    pXDSLLine->Enable  = bValue;
 	    //Process DSL enable set
-	    DmlXdslLineSetEnable( ( pXDSLLine->ulInstanceNumber - 1 ), pXDSLLine->Enable );
+	    DmlXdslLineSetEnable( ( pXDSLLine->ulInstanceNumber ), pXDSLLine->Enable );
     	}
 
         ret = TRUE;


### PR DESCRIPTION
Reason for change:
Corrected the Index number and value during Setting of Device.DSL.Line.1.Enable.

Test Procedure: Setting Device.DSL.Line.1.Enable should bring the
                interface up when true and down when false.
Risks: None.
Signed-off-by: K Sanjay Nayak <k-sanjay.nayak@t-systems.com>