### PR TITLE
RDKBDEV-2883 :Fix for Device.DSL.Channel.%d.Enable is always set to f…

### DIFF
--- a/source/TR-181/integration_src.shared/xdsl_hal.c
+++ b/source/TR-181/integration_src.shared/xdsl_hal.c
@@ -1782,6 +1782,9 @@ int xdsl_hal_dslGetChannelInfo(int channelNo, PDML_XDSL_CHANNEL pstChannelInfo)
                 pstChannelInfo->Status = XDSL_IF_STATUS_Error;
             }
         }
+        else if (strstr (resp_param.name, "Enable")) {
+            pstChannelInfo->Enable = atoi(resp_param.value);
+        }
         else if (strstr (resp_param.name, "LastChange")) {
             pstChannelInfo->LastChange = atoi(resp_param.value);
         }


### PR DESCRIPTION
…alse.

Reason for change:
Added logic to update the value of Enable from dslhal.

Test Procedure: Ensure DM Device.DSL.Channel.%d.Enable DM is in sync with value from dslhal.
Risks: None.