### PR TITLE
SHARMAN-2524 : DSL OverrideTTL RFC set is not working After Factory Reset

### DIFF
--- a/source/TR-181/integration_src.shared/xdsl_report.c
+++ b/source/TR-181/integration_src.shared/xdsl_report.c
@@ -1141,9 +1141,14 @@ static void *StartXdslReporting()
         uOverrideReportingPeriod = XdslReportGetReportingPeriod();
         while(!uOverrideReportingPeriod)
 	{
-	    sleep(5);
+	    sleep(2);
 	    uOverrideReportingPeriod = XdslReportGetReportingPeriod();
-	}	
+	}
+	while(!uDftReportingPeriod)
+	{
+	    sleep(2);
+	    uDftReportingPeriod = XdslReportGetDefaultReportingPeriod();
+	}
         if (uDftOverrideTTL != 0)
         {
             if (uOverrideReportingPeriod == 0)

--- a/source/TR-181/integration_src.shared/xdsl_report.c
+++ b/source/TR-181/integration_src.shared/xdsl_report.c
@@ -1139,6 +1139,11 @@ static void *StartXdslReporting()
         uDftOverrideTTL = XdslReportGetDefaultOverrideTTL();
         uDftReportingPeriod = XdslReportGetDefaultReportingPeriod();
         uOverrideReportingPeriod = XdslReportGetReportingPeriod();
+        while(!uOverrideReportingPeriod)
+	{
+	    sleep(5);
+	    uOverrideReportingPeriod = XdslReportGetReportingPeriod();
+	}	
         if (uDftOverrideTTL != 0)
         {
             if (uOverrideReportingPeriod == 0)


### PR DESCRIPTION
Reason for change: OverrideTTL is set back to 0, since reporting period is still not set. Timing issue.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P2