### PR TITLE
RDKCOM-5059 RDKBDEV-2903 :Implement xTUC and xTUR configuration fields Data models in xDSLManager

### DIFF
--- a/config/RdkXdslManager.xml
+++ b/config/RdkXdslManager.xml
@@ -344,8 +344,48 @@
             </parameter>
             <parameter>
               <name>XTURVendor</name>
-              <type>string(9)</type>
+              <type>hexBinary(4:4)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTURVersion</name>
+              <type>string(17)</type>
               <syntax>string</syntax>
+            </parameter>
+            <parameter>
+              <name>XTURSerial</name>
+              <type>string(33)</type>
+              <syntax>string</syntax>
+            </parameter>
+            <parameter>
+              <name>XTURVendorId</name>
+              <type>hexBinary(8:8)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTURSystemVendorId</name>
+              <type>hexBinary(8:8)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTURVendorSpecific</name>
+              <type>hexBinary(2:2)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTURSystemVendor</name>
+              <type>hexBinary(4:4)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTURSystemVendorSpecific</name>
+              <type>hexBinary(2:2)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTURSystemCountry</name>
+              <type>hexBinary(2:2)</type>
+              <syntax>hexBinary</syntax>
             </parameter>
             <parameter>
               <name>XTURCountry</name>
@@ -366,6 +406,36 @@
               <name>XTUCVendor</name>
               <type>string(9)</type>
               <syntax>string</syntax>
+            </parameter>
+            <parameter>
+              <name>XTUCVersion</name>
+              <type>hexBinary(16:16)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTUCSerial</name>
+              <type>string(33)</type>
+              <syntax>string</syntax>
+            </parameter>
+            <parameter>
+              <name>XTUCVendorSpecific</name>
+              <type>hexBinary(2:2)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTUCSystemVendor</name>
+              <type>hexBinary(4:4)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTUCSystemVendorSpecific</name>
+              <type>hexBinary(2:2)</type>
+              <syntax>hexBinary</syntax>
+            </parameter>
+            <parameter>
+              <name>XTUCSystemCountry</name>
+              <type>hexBinary(2:2)</type>
+              <syntax>hexBinary</syntax>
             </parameter>
             <parameter>
               <name>XTUCCountry</name>

--- a/hal_schema/xdsl_hal_schema.json
+++ b/hal_schema/xdsl_hal_schema.json
@@ -230,10 +230,15 @@
         { "$ref": "#/definitions/dslLineUpstreamPower" },
         { "$ref": "#/definitions/dslLineDownstreamPower" },
         { "$ref": "#/definitions/dslLineXTURVendor" },
+        { "$ref": "#/definitions/dslLineXTURVersion" },
+        { "$ref": "#/definitions/dslLineXTURSerial" },
         { "$ref": "#/definitions/dslLineXTURCountry" },
         { "$ref": "#/definitions/dslLineXTURANSIStd" },
         { "$ref": "#/definitions/dslLineXTURANSIRev" },
         { "$ref": "#/definitions/dslLineXTUCVendor" },
+        { "$ref": "#/definitions/dslLineXTUCVersion" },
+        { "$ref": "#/definitions/dslLineXTUCSerial" },
+        { "$ref": "#/definitions/dslLineXTUCVendorSpecific" },
         { "$ref": "#/definitions/dslLineXTUCCountry" },
         { "$ref": "#/definitions/dslLineXTUCANSIStd" },
         { "$ref": "#/definitions/dslLineXTUCANSIRev" },
@@ -1438,6 +1443,46 @@
       }
     },
 
+    "dslLineXTURVendorSpecific": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^Device\\.DSL\\.Line\\.\\d+\\.XTURVendorSpecific$"
+        },
+        "type": {
+          "type": "string",
+          "const": "hexBinary"
+        },
+        "value": {
+          "$ref": "#/definitions/typeHex",
+          "minLength": 2,
+          "maxLength": 2
+        }
+      }
+    },
+
+    "dslLineXTURSystemVendorId": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^Device\\.DSL\\.Line\\.\\d+\\.XTURSystemVendorId$"
+        },
+        "type": {
+          "type": "string",
+          "const": "hexBinary"
+        },
+        "value": {
+          "$ref": "#/definitions/typeHex",
+          "minLength": 8,
+          "maxLength": 8
+        }
+      }
+    },
+
     "dslLineXTURCountry": {
       "type": "object",
       "additionalProperties": false,
@@ -1512,6 +1557,86 @@
           "$ref": "#/definitions/typeHex",
           "minLength": 8,
           "maxLength": 8
+        }
+      }
+    },
+
+    "dslLineXTUCSystemVendorId": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^Device\\.DSL\\.Line\\.\\d+\\.XTUCSystemVendorId$"
+        },
+        "type": {
+          "type": "string",
+          "const": "hexBinary"
+        },
+        "value": {
+          "$ref": "#/definitions/typeHex",
+          "minLength": 8,
+          "maxLength": 8
+        }
+      }
+    },
+
+    "dslLineXTUCVersion": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^Device\\.DSL\\.Line\\.\\d+\\.XTUCVersion$"
+        },
+        "type": {
+          "type": "string",
+          "const": "hexBinary"
+        },
+        "value": {
+          "$ref": "#/definitions/typeHex",
+          "minLength": 16,
+          "maxLength": 16
+        }
+      }
+    },
+
+    "dslLineXTUCSerial": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^Device\\.DSL\\.Line\\.\\d+\\.XTUCSerial$"
+        },
+        "type": {
+          "type": "string",
+          "const": "hexBinary"
+        },
+        "value": {
+          "$ref": "#/definitions/typeHex",
+          "minLength": 32,
+          "maxLength": 32
+        }
+      }
+    },
+
+    "dslLineXTUCVendorSpecific": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^Device\\.DSL\\.Line\\.\\d+\\.XTUCVendorSpecific$"
+        },
+        "type": {
+          "type": "string",
+          "const": "hexBinary"
+        },
+        "value": {
+          "$ref": "#/definitions/typeHex",
+          "minLength": 2,
+          "maxLength": 2
         }
       }
     },

--- a/source/TR-181/include/xdsl_apis.h
+++ b/source/TR-181/include/xdsl_apis.h
@@ -45,6 +45,8 @@
 
 
 #define XDSL_STANDARD_USED_STR_MAX          64
+#define SYSTEM_VENDOR_ID_LENGTH             16
+#define BEGINNING_INDEX                     4
 
 typedef enum
 _DML_XDSL_LINE_TYPE
@@ -253,12 +255,27 @@ _DML_XDSL_LINE
     INT                               DownstreamAttenuation;
     INT                               DownstreamNoiseMargin;
     INT                               DownstreamPower;
+    CHAR                              XTURSerial[33];
+    CHAR                              XTURVersion[17];
     CHAR                              XTURVendor[9];
+    CHAR                              XTURSystemCountry[5];
+    CHAR                              XTURSystemVendor[9];
+    CHAR                              XTURVendorSpecific[5];
+    CHAR                              XTURSystemVendorSpecific[5];
     CHAR                              XTURCountry[5];
     UINT                              XTURANSIStd;
     UINT                              XTURANSIRev;
     CHAR                              XTUCVendor[9];
+    CHAR                              XTUCVersion[33];
+    CHAR                              XTUCSerial[33];
+    CHAR                              XTUCSystemVendorId[17];
+    CHAR                              XTUCVersionNumber[17];
+    CHAR                              XTUCSerialNumber[33];
+    CHAR                              XTUCVendorSpecific[5];
+    CHAR                              XTUCSystemVendor[9];
+    CHAR                              XTUCSystemVendorSpecific[5];
     CHAR                              XTUCCountry[5];
+    CHAR                              XTUCSystemCountry[5];
     UINT                              XTUCANSIStd;
     UINT                              XTUCANSIRev;
     DML_XDSL_LINE_STATS               stLineStats;

--- a/source/TR-181/integration_src.shared/xdsl_apis.c
+++ b/source/TR-181/integration_src.shared/xdsl_apis.c
@@ -110,6 +110,11 @@
 //XDSL
 #define XDSL_LINE_ENABLE "Device.DSL.Line.%d.Enable"
 #define XDSL_LINE_DATA_GATHERING_ENABLE "Device.DSL.Line.%d.EnableDataGathering"
+#define XDSL_LINE_XTURVERSION  "Device.DSL.Line.%d.XTURVersion"
+#define XDSL_LINE_XTURSERIAL   "Device.DSL.Line.%d.XTURSerial"
+#define MAX_XTURVERSION_LENGTH 17
+#define MAX_XTURSERIAL_LENGTH 33
+#define MAX_STRING_SIZE   64
 
 /* *********************************************************************** */
 //Global Declaration
@@ -122,6 +127,7 @@ extern char * XdslReportStatusDfltReportingPeriod;
 extern char * XdslReportStatusReportingPeriod;
 
 static ANSC_STATUS DmlXdslGetLineStaticInfo( INT LineIndex, PDML_XDSL_LINE pstLineInfo );
+static ANSC_STATUS DmlXdslSetLineInfo( INT LineIndex);
 static ANSC_STATUS DmlXdslGetParamValues( char *pComponent, char *pBus, char *pParamName, char *pReturnVal );
 static ANSC_STATUS DmlXdslSetParamValues( char *pComponent, char *pBus, char *pParamName, char *pParamVal, enum dataType_e type, BOOLEAN bCommit );
 static ANSC_STATUS DmlXdslGetParamNames( char *pComponent, char *pBus, char *pParamName, char a2cReturnVal[][256], int *pReturnSize );
@@ -252,6 +258,7 @@ DmlXdslLineInit
         pXDSLLineTmp[iLoopCount].ulInstanceNumber   = iLoopCount + 1;
 
         DmlXdslGetLineStaticInfo( iLoopCount, &pXDSLLineTmp[iLoopCount] );
+	DmlXdslSetLineInfo( iLoopCount);
     }
 
     //Assign the memory address to oringinal structure
@@ -283,6 +290,46 @@ static ANSC_STATUS DmlXdslGetLineStaticInfo( INT LineIndex, PDML_XDSL_LINE pstLi
 
     //As of now hardcoded
     snprintf( pstLineInfo->StandardsSupported, sizeof(pstLineInfo->StandardsSupported), "%s", "G.992.1_Annex_A, G.992.1_Annex_B, G.992.1_Annex_C, T1.413, G.992.2, G.992.3_Annex_A, G.992.3_Annex_B, G.992.3_Annex_C, G.993.1, G.993.1_Annex_A, G.993.2_Annex_B, G.993.2_Annex_C" );
+
+    return ANSC_STATUS_SUCCESS;
+}
+
+/* DmlXdslSetLineInfo() */
+static ANSC_STATUS DmlXdslSetLineInfo( INT LineIndex)
+{
+    char fName[ANSC_MAX_STRING_SIZE] = {0} , Model[ANSC_MAX_STRING_SIZE] = {0}, Serial[ANSC_MAX_STRING_SIZE] = {0};
+
+    if (platform_hal_GetSerialNumber(Serial) == RETURN_OK )
+    {
+        /* collect value*/
+        if (platform_hal_GetFirmwareName(fName, ANSC_MAX_STRING_SIZE) == RETURN_OK )
+        {
+            if (platform_hal_GetModelName(Model) == RETURN_OK )
+            {
+                hal_param_t set_param;
+
+                /* XTURVersion in BCM Level */
+                memset(&set_param, 0, sizeof(set_param));
+                set_param.type = PARAM_STRING;
+                snprintf(set_param.name, sizeof(set_param.name), XDSL_LINE_XTURVERSION, LineIndex + 1);
+                snprintf(set_param.value,MAX_XTURVERSION_LENGTH,"%s %s",fName,Model);
+                xtm_hal_setLinkInfoParam(&set_param);
+
+                /* XTURSerial in BCM */
+                memset(&set_param, 0, sizeof(set_param));
+                set_param.type = PARAM_STRING;
+                snprintf(set_param.name, sizeof(set_param.name), XDSL_LINE_XTURSERIAL, LineIndex + 1);
+                snprintf(set_param.value,MAX_XTURSERIAL_LENGTH,"%s %s %s",Serial, Model, fName);
+                xtm_hal_setLinkInfoParam(&set_param);
+            }
+            else
+                return ANSC_STATUS_FAILURE;
+        }
+        else
+            return ANSC_STATUS_FAILURE;
+    }
+    else
+        return ANSC_STATUS_FAILURE;
 
     return ANSC_STATUS_SUCCESS;
 }

--- a/source/TR-181/integration_src.shared/xdsl_hal.c
+++ b/source/TR-181/integration_src.shared/xdsl_hal.c
@@ -1048,16 +1048,74 @@ int xdsl_hal_dslGetLineInfo(int lineNo, PDML_XDSL_LINE pstLineInfo)
             snprintf(pstLineInfo->SNRMpbds, sizeof(pstLineInfo->SNRMpbds), "%s", resp_param.value);
         }
         else if (strstr (resp_param.name, "XTURVendor")) {
-            snprintf(pstLineInfo->XTURVendor, sizeof(pstLineInfo->XTURVendor), "%s", resp_param.value);
+            char node[64] = {0};
+            sscanf(resp_param.name,"%*[^.].%*[^.].%*[^.].%*[^.].%64s",node);
+
+            if (strcmp (node,"XTURVendor") == 0)
+            {
+                snprintf(pstLineInfo->XTURVendor, sizeof(pstLineInfo->XTURVendor), "%s", resp_param.value);
+            }
+            else if (strcmp (node, "XTURVendorSpecific") == 0 ) {
+                snprintf(pstLineInfo->XTURVendorSpecific, sizeof(pstLineInfo->XTURVendorSpecific), "%s", resp_param.value);
+            }
+        }
+        else if (strstr (resp_param.name, "XTURSystemCountry")) {
+            snprintf(pstLineInfo->XTURSystemCountry, sizeof(pstLineInfo->XTURSystemCountry), "%s", resp_param.value);
+        }
+        else if (strstr (resp_param.name, "XTURSystemVendor")) {
+            char node[64] = {0};
+            sscanf(resp_param.name,"%*[^.].%*[^.].%*[^.].%*[^.].%64s",node);
+
+            if (strcmp (node, "XTURSystemVendor") == 0) {
+                snprintf(pstLineInfo->XTURSystemVendor, sizeof(pstLineInfo->XTURSystemVendor), "%s", resp_param.value);
+            }
+            else if (strcmp (node, "XTURSystemVendorSpecific") == 0) {
+                snprintf(pstLineInfo->XTURSystemVendorSpecific, sizeof(pstLineInfo->XTURSystemVendorSpecific), "%s", resp_param.value);
+            }
         }
         else if (strstr (resp_param.name, "XTURCountry")) {
             snprintf(pstLineInfo->XTURCountry, sizeof(pstLineInfo->XTURCountry), "%s", resp_param.value);
         }
         else if (strstr (resp_param.name, "XTUCVendor")) {
-            snprintf(pstLineInfo->XTUCVendor, sizeof(pstLineInfo->XTUCVendor), "%s", resp_param.value);
+            char node[64] = {0};
+            sscanf(resp_param.name,"%*[^.].%*[^.].%*[^.].%*[^.].%64s",node);
+
+            if (strcmp (node,"XTUCVendor") == 0)
+            {
+                snprintf(pstLineInfo->XTUCVendor, sizeof(pstLineInfo->XTUCVendor), "%s", resp_param.value);
+            }
+            else if (strcmp (node, "XTUCVendorSpecific") == 0) {
+                snprintf(pstLineInfo->XTUCVendorSpecific, sizeof(pstLineInfo->XTUCVendorSpecific), "%s", resp_param.value);
+            }
+        }
+        else if (strstr (resp_param.name, "XTUCSystemVendor")) {
+            char node[64] = {0};
+            sscanf(resp_param.name,"%*[^.].%*[^.].%*[^.].%*[^.].%64s",node);
+
+            if (strcmp (node, "XTUCSystemVendor") == 0) {
+                snprintf(pstLineInfo->XTUCSystemVendor, sizeof(pstLineInfo->XTUCSystemVendor), "%s", resp_param.value);
+            }
+            else if (strcmp (node, "XTUCSystemVendorSpecific") == 0) {
+                snprintf(pstLineInfo->XTUCSystemVendorSpecific, sizeof(pstLineInfo->XTUCSystemVendorSpecific), "%s", resp_param.value);
+            }
+        }
+        else if (strstr (resp_param.name, "XTURVersion")) {
+            snprintf(pstLineInfo->XTURVersion, sizeof(pstLineInfo->XTURVersion), "%s", resp_param.value);
+        }
+        else if (strstr (resp_param.name, "XTURSerial")) {
+            snprintf(pstLineInfo->XTURSerial, sizeof(pstLineInfo->XTURSerial), "%s", resp_param.value);
+        }
+        else if (strstr (resp_param.name, "XTUCVersion")) {
+            snprintf(pstLineInfo->XTUCVersion, sizeof(pstLineInfo->XTUCVersion), "%s", resp_param.value);
+        }
+        else if (strstr (resp_param.name, "XTUCSerial")) {
+            snprintf(pstLineInfo->XTUCSerial, sizeof(pstLineInfo->XTUCSerial), "%s", resp_param.value);
         }
         else if (strstr (resp_param.name, "XTUCCountry")) {
             snprintf(pstLineInfo->XTUCCountry, sizeof(pstLineInfo->XTUCCountry), "%s", resp_param.value);
+        }
+        else if (strstr (resp_param.name, "XTUCSystemCountry")) {
+            snprintf(pstLineInfo->XTUCSystemCountry, sizeof(pstLineInfo->XTUCSystemCountry), "%s", resp_param.value);
         }
         else if (strstr (resp_param.name, "UPBOKLEPb")) {
             snprintf(pstLineInfo->UPBOKLEPb, sizeof(pstLineInfo->UPBOKLEPb), "%s", resp_param.value);
@@ -2197,8 +2255,8 @@ ANSC_STATUS xtm_hal_setLinkInfoParam(hal_param_t *set_param)
     /**
      * XTM Link Enable/Disable
      */
-    json_object *jreply_msg;
-    json_object *jrequest;
+    json_object *jreply_msg = NULL;
+    json_object *jrequest = NULL;
     int rc = ANSC_STATUS_FAILURE;
     json_bool status = FALSE;
 
@@ -2590,6 +2648,12 @@ static json_object *create_json_request_message(eActionType request_type, const 
                 strncpy(stParam.value, "false", sizeof(stParam.value));
             }
             json_hal_add_param(jrequest, SET_REQUEST_MESSAGE, &stParam);
+            break;
+        case PARAM_STRING:
+            {
+                strncpy(stParam.value, param_val, sizeof(stParam.value));
+                json_hal_add_param(jrequest, SET_REQUEST_MESSAGE, &stParam);
+            }
             break;
         }
         break;

--- a/source/TR-181/middle_layer_src/Makefile.am
+++ b/source/TR-181/middle_layer_src/Makefile.am
@@ -31,4 +31,4 @@ libXdslManagermiddle_layer_src_la_CPPFLAGS = \
 
 libXdslManagermiddle_layer_src_la_SOURCES = plugin_main.c plugin_main_apis.c xdsl_dml.c xdsl_internal.c xtm_dml.c xtm_internal.c
 
-libXdslManagermiddle_layer_src_la_LDFLAGS = -lccsp_common -lcm_mgnt
+libXdslManagermiddle_layer_src_la_LDFLAGS = -lccsp_common -lcm_mgnt -lhal_platform

--- a/source/TR-181/middle_layer_src/xdsl_dml.c
+++ b/source/TR-181/middle_layer_src/xdsl_dml.c
@@ -533,6 +533,35 @@ Line_GetParamStringValue
            ret = 1;
        }
     }
+    else if( AnscEqualString(ParamName, "XTURVersion", TRUE) )
+    {
+       /* collect value*/
+       if ( ( sizeof( pXDSLLine->XTURVersion ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString( pValue, pXDSLLine->XTURVersion );
+           ret = 0;
+
+       }
+       else
+       {
+           *pUlSize = sizeof( pXDSLLine->XTURVendor );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTURSerial", TRUE) )
+    {
+       /* collect value */
+       if ( ( sizeof( pXDSLLine->XTURSerial ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString( pValue, pXDSLLine->XTURSerial );
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof( pXDSLLine->XTURSerial );
+           ret = 1;
+       }
+    }
     else if (strcmp(ParamName, "XTUCVendor") == 0)
     {
        /* collect value */
@@ -544,6 +573,90 @@ Line_GetParamStringValue
        else
        {
            *pUlSize = sizeof( pXDSLLine->XTUCVendor );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTUCSystemVendor", TRUE) )
+    {
+       /* collect value */
+       if ( ( sizeof( pXDSLLine->XTUCSystemVendor ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString( pValue, pXDSLLine->XTUCSystemVendor );
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof( pXDSLLine->XTUCSystemVendor );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTUCSystemVendorSpecific", TRUE) )
+    {
+       /* collect value */
+       if ( ( sizeof( pXDSLLine->XTUCSystemVendorSpecific ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString( pValue, pXDSLLine->XTUCSystemVendorSpecific );
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof( pXDSLLine->XTUCSystemVendorSpecific );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTUCSystemCountry", TRUE) )
+    {
+       /* collect value */
+       if ( ( sizeof( pXDSLLine->XTUCSystemCountry ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString( pValue, pXDSLLine->XTUCSystemCountry );
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof( pXDSLLine->XTUCSystemCountry );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTUCVersion", TRUE) )
+    {
+       /* collect value */
+       if ( ( sizeof( pXDSLLine->XTUCVersion ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString( pValue, pXDSLLine->XTUCVersion );
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof( pXDSLLine->XTUCVersion );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTUCSerial", TRUE) )
+    {
+       /* collect value */
+       if ( ( sizeof( pXDSLLine->XTUCSerial ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString( pValue, pXDSLLine->XTUCSerial );
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof( pXDSLLine->XTUCSerial );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTUCVendorSpecific", TRUE) )
+    {
+       /* collect value */
+       if ( ( sizeof( pXDSLLine->XTUCVendorSpecific ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString( pValue, pXDSLLine->XTUCVendorSpecific );
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof( pXDSLLine->XTUCVendorSpecific );
            ret = 1;
        }
     }
@@ -614,6 +727,92 @@ Line_GetParamStringValue
        else
        {
            *pUlSize = sizeof( pXDSLLine->XTSE );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTURVendorSpecific", TRUE) )
+    {
+       /* collect value*/
+       if ( ( sizeof( pXDSLLine->XTURVendorSpecific ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString( pValue, pXDSLLine->XTURVendorSpecific );
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof( pXDSLLine->XTURVendorSpecific );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTURSystemVendorId", TRUE) )
+    {
+       /* collect value */
+       int length = sizeof (pXDSLLine->XTURSystemCountry) + sizeof(pXDSLLine->XTURSystemVendor) + sizeof(pXDSLLine->XTURSystemVendorSpecific);
+       if ( ( length ) < *pUlSize )
+       {
+           snprintf(pValue, *pUlSize, "%s%s%s", pXDSLLine->XTURSystemCountry, pXDSLLine->XTURSystemVendor, pXDSLLine->XTURSystemVendorSpecific);
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = length;
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTURVendorId", TRUE) )
+    {
+       /* collect value */
+       int length = sizeof (pXDSLLine->XTURCountry) + sizeof(pXDSLLine->XTURVendor) + sizeof(pXDSLLine->XTURVendorSpecific);
+       if ( ( length ) < *pUlSize )
+       {
+           snprintf(pValue, *pUlSize, "%s%s%s", pXDSLLine->XTURCountry, pXDSLLine->XTURVendor, pXDSLLine->XTURVendorSpecific);
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = length;
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTURSystemVendor", TRUE) )
+    {
+       /* collect value */
+       if ( ( sizeof( pXDSLLine->XTURSystemVendor ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString(pValue, pXDSLLine->XTURSystemVendor);
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof(  pXDSLLine->XTURSystemVendor );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTURSystemVendorSpecific", TRUE) )
+    {
+       /* collect value*/
+       if ( ( sizeof( pXDSLLine->XTURSystemVendorSpecific ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString(pValue, pXDSLLine->XTURSystemVendorSpecific);
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof(  pXDSLLine->XTURSystemVendorSpecific );
+           ret = 1;
+       }
+    }
+    else if( AnscEqualString(ParamName, "XTURSystemCountry", TRUE) )
+    {
+       /* collect value */
+       if ( ( sizeof( pXDSLLine->XTURSystemCountry ) - 1 ) < *pUlSize )
+       {
+           AnscCopyString(pValue, pXDSLLine->XTURSystemCountry);
+           ret = 0;
+       }
+       else
+       {
+           *pUlSize = sizeof(  pXDSLLine->XTURSystemCountry );
            ret = 1;
        }
     }


### PR DESCRIPTION
Reason for change:
Implement xTUC and xTUR configuration fields Data models as TR181 under Device.DSL .

Test Procedure: xTUC and xTUR  Data models fields should be updated with correct values.
Risks: None.