### PR TITLE
RDKB-56987: [64BIT] Fix Runtime crash with RdkXdslManager

### DIFF
--- a/source/TR-181/integration_src.shared/xdsl_apis.c
+++ b/source/TR-181/integration_src.shared/xdsl_apis.c
@@ -76,6 +76,12 @@
 #include <net/if.h>
 
 //Specific includes
+#include "ansc_platform.h"
+#include "xtm_dml.h"
+#include "xtm_apis.h"
+#include "plugin_main_apis.h"
+#include "xtm_internal.h"
+#include "ccsp_psm_helper.h"
 #include "xdsl_apis.h"
 #include "xdsl_hal.h"
 #include "xdsl_internal.h"

--- a/source/TR-181/integration_src.shared/xdsl_event_queue.c
+++ b/source/TR-181/integration_src.shared/xdsl_event_queue.c
@@ -42,6 +42,9 @@
 
 extern int sysevent_fd;
 
+extern ANSC_HANDLE ATMLink_GetEntry ( ANSC_HANDLE hInsContext, ULONG nIndex, ULONG* pInsNumber );
+extern ANSC_HANDLE PTMLink_GetEntry (ANSC_HANDLE hInsContext,ULONG nIndex,ULONG* pInsNumber);
+
 typedef enum
 _XDSL_MSGQ_MSG_TYPE
 {

--- a/source/TR-181/integration_src.shared/xdsl_report.c
+++ b/source/TR-181/integration_src.shared/xdsl_report.c
@@ -49,6 +49,8 @@ static ULONG XdslReportOverrideTTL = DEFAULT_OVERRIDE_TTL;
 static ULONG CurrentOverrideReportingPeriod = 0;
 extern ANSC_HANDLE bus_handle;
 char deviceMAC[32] = {'\0'};
+extern int xdsl_hal_dslGetXRdk_Nlm(PDML_XDSL_X_RDK_NLNM pstNlmInfo);
+int XdslReportSetDefaultOverrideTTL(ULONG interval);
 
 static pthread_mutex_t XdslReportMutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t XdslReportCond = PTHREAD_COND_INITIALIZER;

--- a/source/TR-181/integration_src.shared/xtm_apis.c
+++ b/source/TR-181/integration_src.shared/xtm_apis.c
@@ -38,6 +38,8 @@
 
 #define DATAMODEL_PARAM_LENGTH 256
 
+extern ANSC_STATUS atm_hal_startAtmLoopbackDiagnostics(PDML_ATM_DIAG pDiag);
+
 /* * DmlSetPtmIfEnable */
 ANSC_STATUS DmlSetPtmIfEnable (PDML_PTM p_Ptm)
 {

--- a/source/TR-181/middle_layer_src/Makefile.am
+++ b/source/TR-181/middle_layer_src/Makefile.am
@@ -26,6 +26,7 @@ libXdslManagermiddle_layer_src_la_CPPFLAGS = \
     -I$(top_srcdir)/source/TR-181/board_sbapi \
     -I$(top_srcdir)/source/TR-181/middle_layer_src \
     -I$(top_srcdir)/source/TR-181/include \
+    -I$(top_srcdir)/source/TR-181/integration_src.shared \
     -I$(top_srcdir)/source/RdkXdslManager
 
 libXdslManagermiddle_layer_src_la_SOURCES = plugin_main.c plugin_main_apis.c xdsl_dml.c xdsl_internal.c xtm_dml.c xtm_internal.c

--- a/source/TR-181/middle_layer_src/plugin_main_apis.c
+++ b/source/TR-181/middle_layer_src/plugin_main_apis.c
@@ -66,6 +66,8 @@
 //#include "dml_tr181_custom_cfg.h"
 #include "plugin_main_apis.h"
 #include "xdsl_apis.h"
+#include "xdsl_internal.h"
+#include "xtm_internal.h"
 
 /*PCOSA_DIAG_PLUGIN_INFO             g_pCosaDiagPluginInfo;*/
 COSAGetParamValueByPathNameProc    g_GetParamValueByPathNameProc;

--- a/source/TR-181/middle_layer_src/xdsl_dml.c
+++ b/source/TR-181/middle_layer_src/xdsl_dml.c
@@ -69,10 +69,14 @@
 #include "xdsl_apis.h"
 #include "xdsl_dml.h"
 #include "xdsl_internal.h"
+#include "xdsl_report.h"
+#include "ccsp_psm_helper.h"
 
 char * XdslReportStatusEnable = "eRT.com.cisco.spvtg.ccsp.xdslmanager.Enabled"; 
 char * XdslReportStatusDfltReportingPeriod = "eRT.com.cisco.spvtg.ccsp.xdslmanager.Default.ReportingPeriod"; 
 char * XdslReportStatusReportingPeriod = "eRT.com.cisco.spvtg.ccsp.xdslmanager.ReportingPeriod"; 
+extern int XdslReportSetDefaultOverrideTTL(ULONG interval);
+extern int XdslReportSetDefaultReportingPeriod(ULONG interval);
 
 extern ANSC_HANDLE                   bus_handle;
 extern char                          g_Subsystem[32];

--- a/source/TR-181/middle_layer_src/xtm_internal.c
+++ b/source/TR-181/middle_layer_src/xtm_internal.c
@@ -38,6 +38,9 @@
 #include "plugin_main_apis.h"
 #include "sys_definitions.h"
 #include "xdsl_hal.h"
+#include "ccsp_psm_helper.h"
+
+extern ANSC_STATUS DmlAtmInit(ANSC_HANDLE hDml, PANSC_HANDLE phContext);
 
 /**********************************************************************
 

--- a/source/TR-181/middle_layer_src/xtm_internal.h
+++ b/source/TR-181/middle_layer_src/xtm_internal.h
@@ -36,6 +36,7 @@
 #define  _XTM_INTERNAL_H
 
 #include "cosa_apis.h"
+#include "xtm_apis.h"
 /***********************************
     Actual definition declaration
 ************************************/


### PR DESCRIPTION
RdkXdslManager process is crashing in 64bit mode against kirkstone yocto version. The crash was due to pointer corruption as function return type casting to wrong type causing 64bit address truncated to 32bit and eventually pointer corrupted and crash occurred.

Here we could see in caller area, there is implicit function errors which as treated as warning during compilation. This is causing even though functions executed properly but when caller cast it into corresponding type, its return type wrongly mapped and resulted in corruption.

This change is mainly includes make sure all implicit-function declaration warning resolved and return values in the functions are properly handled in caller area.