### PR TITLE
RDKB-58019 : Adding version log.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,12 @@ AC_ARG_ENABLE([gtestapp],
              [echo "Gtestapp is disabled"])
 AM_CONDITIONAL([WITH_GTEST_SUPPORT], [test x$GTEST_SUPPORT_ENABLED = xtrue])
 
+#Add git version
+m4_define([GITVERSION],
+  m4_esyscmd_s([git describe --tags --always --dirty 2>/dev/null || echo "undefined"])
+)
+AC_SUBST([GIT_VERSION], [GITVERSION])
+
 dnl subdirectories.
 SUBDIRS=""
 

--- a/source/RdkXdslManager/Makefile.am
+++ b/source/RdkXdslManager/Makefile.am
@@ -34,3 +34,4 @@ xdslmanager_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(DBUS_CFLAGS) $(SYSTEMD_CFLAGS)
 xdslmanager_SOURCES = apis_xdslmanagerplugin.c ssp_action.c ssp_messagebus_interface.c ssp_main.c
 xdslmanager_LDFLAGS = -lccsp_common -lrdkloggers -lcm_mgnt -lsyscfg -lbreakpadwrapper $(DBUS_LIBS) $(SYSTEMD_LDFLAGS)
 xdslmanager_LDADD = $(xdslmanager_DEPENDENCIES)
+xdslmanager_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"

--- a/source/RdkXdslManager/ssp_main.c
+++ b/source/RdkXdslManager/ssp_main.c
@@ -282,6 +282,7 @@ int main(int argc, char* argv[])
 
     //rdklogger init
     rdk_logger_init(DEBUG_INI_NAME);
+    CcspTraceInfo(("Version : %s \n",GIT_VERSION ));
 
     if ( bRunAsDaemon ) 
         daemonize();


### PR DESCRIPTION
Reason for change:  Adding version log using "git describe --tags --always --dirty" command Example :
RC2.7.0a-1-g5aa0583-dirty
Tag: RC2.7.0a (Most recent tag)
Number of Commits Ahead: -1 (1 commit after the tag) Commit Hash: g5aa0583 ( "5aa0583" Hash of the current commit) Uncommitted Changes: -dirty (Changes not yet committed)

Test Procedure:
Version log should be present.

Priority: P1
Risks: none