### PR TITLE
SHARMAN-3315:Permission denied errors for XTURVersion and XTURSerial

### DIFF
--- a/source/TR-181/integration_src.shared/xdsl_apis.c
+++ b/source/TR-181/integration_src.shared/xdsl_apis.c
@@ -299,12 +299,15 @@ static ANSC_STATUS DmlXdslSetLineInfo( INT LineIndex)
 {
     char fName[ANSC_MAX_STRING_SIZE] = {0} , Model[ANSC_MAX_STRING_SIZE] = {0}, Serial[ANSC_MAX_STRING_SIZE] = {0};
 
-    if (platform_hal_GetSerialNumber(Serial) == RETURN_OK )
+    if ((platform_hal_GetSerialNumber(Serial) == RETURN_OK ) &&
+        (strlen(Serial) > 0))
     {
         /* collect value*/
-        if (platform_hal_GetFirmwareName(fName, ANSC_MAX_STRING_SIZE) == RETURN_OK )
+        if ((platform_hal_GetFirmwareName(fName, ANSC_MAX_STRING_SIZE) == RETURN_OK )
+           (strlen(fName) > 0))
         {
-            if (platform_hal_GetModelName(Model) == RETURN_OK )
+            if ((platform_hal_GetModelName(Model) == RETURN_OK )
+                (strlen(Model) > 0))
             {
                 hal_param_t set_param;
 


### PR DESCRIPTION
Reason for change: failed to set the Parameters XTURVersion and XTURSerial Test Procedure:
1.)should not see the set error message in XDSL logs. Risks: Medium
Priority: P2
Signed-off-by: kulvendra singh <kulvendra.singh@sky.uk>